### PR TITLE
Documentation, comments, & spacing updates

### DIFF
--- a/isettools/bipolar/@bipolarMosaic/Contents.m
+++ b/isettools/bipolar/@bipolarMosaic/Contents.m
@@ -1,0 +1,11 @@
+% @BIPOLARMOSAIC
+%
+% Files
+%   bipolarMosaic - Create a bipolar mosaic object
+%   bipolarSet    - Retrieve isetbio bipolar object parameters
+%   compute       - Compute bipolar continuous current responses
+%   describe      - Summarize the bipolar mosaic properties in a string.
+%   get           - Retrieve the isetbio bipolar object parameters
+%   initSpace     - Build spatial receptive fields for the bipolar mosaic
+%   plot          - Plot data from a bipolar mosaic object
+%   set           - Gets isetbio bipolar object parameters.

--- a/isettools/bipolar/@bipolarMosaic/bipolarMosaic.m
+++ b/isettools/bipolar/@bipolarMosaic/bipolarMosaic.m
@@ -1,78 +1,91 @@
 classdef bipolarMosaic < cellMosaic
-%BIPOLARMOSAIC - Create a bipolar mosaic object
+% Syntax:
 %
-% The bipolar mosaic class is a subclass of cellMosaic. It is used to
-% simulate the processing from the cone outer segment current to the
-% bipolar cell current output. 
+%   bp = bipolarMosaic(coneMosaic, 'PARAM1', val1, 'PARAM2', val2, ...)
 %
-% To create the bipolar mosaic, use
-% 
-%   bp = bipolarMosaic(coneMosaic, 'PARAM1', val1, 'PARAM2', val2,...) 
+% Description:
+%    Create a bipolar mosaic object
 %
-% Optional parameter name/value pairs are listed below.
+%    The bipolar mosaic class is a subclass of cellMosaic. It is used to
+%    simulate the processing from the cone outer segment current to the
+%    bipolar cell current output. 
+%
+% Input:
+%    coneMosaic    - cone mosaic object including photocurrent response
+%
+% Optional Key/Value Pairs
+%    The bipolar object also allows for the simulation of nonlinear
+%    subunits within retinal ganglion cell spatial receptive fields.
+%
+%    cellLocation          - location of bipolar RF center
+%    cellType              - there are five different cell types
+%    patchSize             - size of retinal patch from sensor
+%    timeStep              - time step of simulation from sensor
+%    filterType            - bipolar temporal filter type
+%    RFcenter              - spatial RF of the center on receptor grid
+%    sRFsurround           - spatial RF of the surround on receptor grid
+%    rectificationCenter   - nonlinear function for center
+%    rectificationSurround - nonlinear function for surround
+%    responseCenter        - Store the linear response of the center
+%                            after convolution
+%    responseSurround      - Store the linear response of the surround
+%                            after convolution  
 % 
-% The bipolar object also allows for the simulation of nonlinear subunits
-% within retinal ganglion cell spatial receptive fields.
-% 
-% Input (Required):
-%  coneMosaic: a cone mosaic object that includes the photocurrent response
-% 
-% Input (Parameter-Value pairs):
-%     cellLocation;                    % location of bipolar RF center
-%     cellType;                        % there are five different cell types
-%     patchSize;                       % size of retinal patch from sensor
-%     timeStep;                        % time step of simulation from sensor
-%     filterType;                      % bipolar temporal filter type
-%     sRFcenter;                       % spatial RF of the center on the receptor grid
-%     sRFsurround;                     % spatial RF of the surround on the receptor grid
-%     rectificationCenter              % nonlinear function for center
-%     rectificationSurround            % nonlinear function for surround
-%     responseCenter;                  % Store the linear response of the center after convolution
-%     responseSurround;                % Store the linear response of the surround after convolution  
-% 
-%  ISETBIO wiki: <a href="matlab:
-%  web('https://github.com/isetbio/isetbio/wiki/bipolar','-browser')">bipolar</a>.
+% References:
+%    ISETBIO wiki: https://github.com/isetbio/isetbio/wiki/bipolar
 %  
-% Scientific notes and references
-%  We do not have a validated model of the bipolar temporal impulse
-%  response.  To simulate it, we assume that the RGC responses from the
-%  cone photocurrent as measured by EJ is correct.  The bipolar temporal
-%  impulse response (tIR) is the response necessary to combine with the
-%  cone temporal tIR to equal the RGC tIR.
+%    Scientific notes and references
+%    We do not have a validated model of the bipolar temporal impulse
+%    response.  To simulate it, we assume that the RGC responses from the
+%    cone photocurrent as measured by EJ is correct.  The bipolar temporal
+%    impulse response (tIR) is the response necessary to combine with the
+%    cone temporal tIR to equal the RGC tIR.
 %
 
+%% History:
 % JRG/BW (c) isetbio team, 2016
+%
+%    10/18/17  jnm  Comments & formatting
+
+%% Examples:
+%{
+   bp = bipolarMosaic(cMosaic, cellType, varargin);
+%}
 
 %% Define object
 % Public, read-only properties.
 properties (SetAccess = private, GetAccess = public)
 end
 
-% Protected properties.
+%% Protected properties.
 properties (SetAccess = protected, GetAccess = public)
-    % TODO: We should specify an amplitude for the center and surround.
+    %%%
+    % *TODO:* We should specify an amplitude for the center and surround.
     % Perhaps we should specify parameters of the receptive fields beyond
     % what is in cellMosaic.
-    
-    % RECTIFICATIONCENTER nonlinear function for center
+    %%%
+    % RectificationCenter nonlinear function for center
     rectificationCenter              
-    
-    % RECTIFICATIONSURROUND nonlinear function for surround
+    %%%
+    % RectificationSurround nonlinear function for surround
     rectificationSurround            
-    
-    % RESPONSECENTER Store the linear response of the center after convolution
+    %%%
+    % ResponseCenter Store the linear response of the center after
+    % convolution
     responseCenter;                  
-    
-    % RESPONSESURROUND Store the linear response of the surround after convolution
+    %%%
+    % ResponseSurround Store the linear response of the surround after
+    % convolution
     responseSurround;
 
 end
 
-% Private properties. Only methods of the parent class can set these
+%% Private properties. Only methods of the parent class can set these
 properties(Access = private)
-    % CONETYPE  
+    %%%
+    % ConeType
     % on diffuse, off diffuse and on midget bipolars get no S cone input
-    % off midget bipolars get L,M,S cone input to center
+    % off midget bipolars get L, M, S cone input to center
     % on sbc bipolars get only S cone center and only L+M surround
     coneType;
 end
@@ -80,36 +93,39 @@ end
 properties (Access = public)
 end
 
-% Public methods
+%% Public methods
 methods
-    
+    %%%
     % Constructor
     function obj = bipolarMosaic(cmosaic, cellType, varargin)     
+        %%%
         % Initialize the bipolar class
-        %
+
         % Example:
-        %   bp = bipolarMosaic(cMosaic,cellType,varargin);
+        %   bp = bipolarMosaic(cMosaic, cellType, varargin);
         %
         % JRG/BW ISETBIO Team, 2016
-        
         p = inputParser;
-        p.KeepUnmatched = true;      % Keeps spread, stride, eccentricity
-        p.addRequired('cmosaic',@(x)(isa(x,'coneMosaic')));
-        p.addRequired('cellType', @(x)(ismember(ieParamFormat(x),obj.validCellTypes)));
+        %%%
+        % KeepUnmatched retains the spread, stride, and eccentricity
+        p.KeepUnmatched = true;
+        p.addRequired('cmosaic', @(x)(isa(x, 'coneMosaic')));
+        p.addRequired('cellType', @(x)(ismember(ieParamFormat(x), ...
+            obj.validCellTypes)));
         
-        p.addParameter('parent',[], @(x)(isa(x,'bipolarLayer')));
+        p.addParameter('parent', [], @(x)(isa(x, 'bipolarLayer')));
         p.addParameter('rectifyType', 1, @isnumeric);
         p.addParameter('filterType',  1, @isnumeric);
 
         p.parse(cmosaic, cellType, varargin{:});  
-        
+        %%%
         % The layer object that this is part of.
         obj.parent    = p.Results.parent;
         obj.input     = p.Results.cmosaic;
-        
+        %%%
         % Store the spatial pattern of input cones
         obj.coneType  = cmosaic.pattern;
-        
+        %%%
         % This might be a mistake, but we store the size and time step of
         % the cone mosaic in this mosaic for easy accessibility.  The
         % cMosaic itself is stored in the layer object that contains this
@@ -118,7 +134,7 @@ methods
         obj.timeStep  = cmosaic.integrationTime;
         
         obj.cellType = ieParamFormat(cellType);
-        
+        %%%
         % Set the rectification operation
         switch p.Results.rectifyType
             case 1
@@ -142,30 +158,31 @@ methods
         end
         
         obj.filterType = p.Results.filterType;
-        
+        %%%
         % Build spatial receptive fields
         obj.initSpace(varargin{:});
 
     end
     
     function window(obj)
+        %%%
         % Tip: Retrieve guidata using
         %    gui = guidata(obj.figureHandle);
         obj.fig = bipolarWindow(obj);
     end
     
-    function bipolarsPerMicron = cellsPerDistance(obj,varargin)
+    function bipolarsPerMicron = cellsPerDistance(obj, varargin)
         p = inputParser;
-        p.addRequired('obj',@(x)(isa(obj,'bipolarMosaic')));
-        p.addParameter('units','m',@ischar);
-        p.parse(obj,varargin{:});
+        p.addRequired('obj', @(x)(isa(obj, 'bipolarMosaic')));
+        p.addParameter('units', 'm', @ischar);
+        p.parse(obj, varargin{:});
         
         patchSizeUM = obj.Parent.size;   % In microns
-        
+        %%%
         % The bipolar mosaics at this point are all the same row/col count.
         % But they may not be in the future.  So, what do we do about that?
         bpRowCol = size(obj.Parent.input.mosaic{1}.cellLocation);    
-        
+        %%%
         % Converts a distance in microns to a number of bipolars per micron
         bipolarsPerMicron = bpRowCol(1:2) ./ patchSizeUM;   % cells/micron
     end
@@ -173,20 +190,22 @@ methods
 end
 
 properties (Constant)
-    % VALIDCELLTYPES 
+    %%%
+    % ValidCellTypes 
     %
     % Cell array of strings containing valid values for the cell type.
     % diffuse and parasol are synonyms.  Not sure we should have them both.
     % And, possibly we should have smallbistratified. (BW)
-    validCellTypes = {'ondiffuse','offdiffuse','onmidget','offmidget','onsbc'};
+    validCellTypes = {'ondiffuse', 'offdiffuse', 'onmidget', ...
+        'offmidget', 'onsbc'};
 end
-
+%%%
 % Methods that must only be implemented (Abstract in parent class).
-
+%%%
 % Methods may be called by the subclasses, but are otherwise private
 methods (Access = protected)
 end
-
+%%%
 % Methods that are totally private (subclasses cannot call these)
 methods (Access = private)
 end

--- a/isettools/bipolar/@bipolarMosaic/bipolarSet.m
+++ b/isettools/bipolar/@bipolarMosaic/bipolarSet.m
@@ -1,45 +1,56 @@
 function obj = bipolarSet(obj, varargin)
-%  Gets isetbio bipolar object parameters.
+% Syntax:
+%
+%   < insert example(s) here >
+%
+% Description:
+%    Gets isetbio bipolar object parameters.
 % 
-% The bipolar object allows the simulated cone responses to be passed on to
-% the inner retina object and to approxiately maintain its impulse
-% response. This will allow us to run the nonlinear biophysical cone outer
-% segment model and pass its results on to the bipolar stage and then RGCs.
-% 
-%     cellLocation;                    % location of bipolar RF center
-%     patchSize;                       % size of retinal patch from sensor
-%     timeStep;                        % time step of simulation from sensor
-%     sRFcenter;                       % spatial RF of the center on the receptor grid
-%     sRFsurround;                     % spatial RF of the surround on the receptor grid
-%     temporalDifferentiator;          % differentiator function
-%     responseCenter;                  % Store the linear response of the center after convolution
-%     responseSurround;                % Store the linear response of the surround after convolution
-% 
-% 
-% 5/2016 JRG (c) isetbio team
-%%
+%    The bipolar object allows the simulated cone responses to be passed on
+%    to the inner retina object and to approxiately maintain its impulse
+%    response. This will allow us to run the nonlinear biophysical cone
+%    outer segment model and pass its results on to the bipolar stage and
+%    then RGCs.
+%
+% Inputs
+%    cellLocation           - location of bipolar RF center
+%    patchSize              - size of retinal patch from sensor
+%    timeStep               - time step of simulation from sensor
+%    sRFcenter              - spatial RF of the center on receptor grid
+%    sRFsurround            - spatial RF of the surround on receptor grid
+%    temporalDifferentiator - differentiator function
+%    responseCenter         - Store the linear response of the center
+%                             after convolution
+%    responseSurround       - Store the linear response of the surround
+%                             after convolution
 
+%% History 
+% 5/2016 JRG (c) isetbio team
+%
+%    10/18/17  jnm  Cpmments & Formatting
+%% Initialize and begin
 narginchk(0, Inf);
 p = inputParser; p.CaseSensitive = false; p.FunctionName = mfilename;
 p.KeepUnmatched = true;
+%%%
 % Make key properties that can be set required arguments, and require
 % values along with key names.
 allowableFieldsToSet = {...
-    'cellLocation',...
-    'patchSize',...
-    'timeStep',...
-    'sRFcenter',...
-    'sRFsurround',...
-    'tIR',...
-    'temporalDifferentiator',...
-    'threshold',...
-    'responseCenter','bipolarresponsecenter',...    
-    'responseSurround','bipolarresponsesurround'...
+    'cellLocation', ...
+    'patchSize', ...
+    'sRFcenter', ...
+    'sRFsurround', ...
+    'responseCenter', 'bipolarresponsecenter', ...
+    'responseSurround', 'bipolarresponsesurround', ...
+    'temporalDifferentiator', ...
+    'threshold', ...
+    'timeStep', ...
+    'tIR'...
     };
-p.addRequired('what',@(x) any(validatestring(ieParamFormat(x),allowableFieldsToSet)));
+p.addRequired('what', @(x) any(validatestring(ieParamFormat(x), ...
+    allowableFieldsToSet)));
 p.addRequired('value');
-
-% Parse and put results into structure p.
+%% Parse and put results into structure p.
 p.parse(varargin{:}); params = p.Results;
 
 switch ieParamFormat(params.what);  % Lower case and remove spaces
@@ -72,4 +83,3 @@ switch ieParamFormat(params.what);  % Lower case and remove spaces
         obj.responseSurround = params.value;
         
 end
-

--- a/isettools/bipolar/@bipolarMosaic/compute.m
+++ b/isettools/bipolar/@bipolarMosaic/compute.m
@@ -1,83 +1,88 @@
 function response = compute(obj, varargin)
-% BIPOLAR.COMPUTE - Compute bipolar continuous current responses
+% Syntax:
+%    The bipolar object handles multiple trials, and these are returned
+%    separately for the center and surround of the biplar model when use
+%    have output arguments, as below.
 %
-%    @bipolarMosaic.compute(varargin);
+%   [~, bpNTrialsCenter, bpNTrialsSurround] = ...
+%           bp.compute(cMosaic, 'nTrialsInput', cMosaicCurrentNTrials);
 %
-% The bipolars act as a spatial-temporal function that converts the cone
-% photocurrent into bipolar current that is delivered to the retinal
-% ganglion cells. The cone mosaic is the input, and it contains a
-% photocurrent time series (coneMosaic.current).
+%   @bipolarMosaic.compute(varargin);
 %
-% The bipolar response is computed with a separable spatio-temporal
-% calculation (first spatial filtering, then temporal filtering) of the
-% cone current to create the bipolar output.
+% Description:
+%    The bipolars act as a spatial-temporal function that converts the cone
+%    photocurrent into bipolar current that is delivered to the retinal
+%    ganglion cells. The cone mosaic is the input, and it contains a
+%    photocurrent time series (coneMosaic.current).
 %
-% The critical bipolar mosaic parameters are set up and stored in the
-% @bipolarMosaic object itself.  This routine computes the responses based
-% on those settings.  See the class definition for the list of parameters.
+%    The bipolar response is computed with a separable spatio-temporal
+%    calculation (first spatial filtering, then temporal filtering) of the
+%    cone current to create the bipolar output.
 %
-% Required input
-%   obj:       a bipolar object
+%    The critical bipolar mosaic parameters are set up and stored in the
+%    @bipolarMosaic object itself. This routine computes the responses
+%    based on those settings. See the class definition for the list of
+%    parameters.
 %
-% Outputs
-%   Response - The response of the bipolar.  N.B. The center and
-%              surround responses are calculated and stored in the mosaic
-%              as responseCenter and responseSurround
+%    The principal decision is whether the bipolar transformation is linear
+%    or includes a rectification. This is controlled by the obj.rectifyType
+%    parameter. The rectification happens at the end of the function, after
+%    both spatial and temporal filtering.
 %
-% The principal decision is whether the bipolar transformation is linear or
-% includes a rectification.  This is controlled by the obj.rectifyType
-% parameter. The rectification happens at the end of the function, after
-% both spatial and temporal filtering.
+% Input:
+%    obj      - A bipolar object
 %
-%  *** This feature has not been tested or much used - on our list
-%  REFERENCE: Meister option
+% Output:
+%    Response - The response of the bipolar. N.B. The center and
+%               surround responses are calculated and stored in the mosaic
+%               as responseCenter and responseSurround
 %
-%  The spatial filtering is followed by a temporal filter that is selected
-%  in order to match the impulse response that expect to find at the RGC
-%  input.  REFERENCE: Chichilnisky option
+% References: 
+%   *Meister option* -
+%       The spatial filtering is followed by a temporal filter that is
+%       selected in order to match the impulse response that expect to find
+%       at the RGC input. 
 %
-% Returns
+%   *Chichilnisky option* -
+%       The cMosaicCurrentNTrials has dimensions (nTrials, row, col,
+%       nFrames), as returned by cmosaic.computeCurrent. The full bipolar
+%       response simply add bpNTrialsCenter + bpNTrialsSurround.
 %
-%  The bipolar object handles multiple trials, and these are returned
-%  separately for the center and surround of the biplar model when use have
-%  output arguments, as below.
+% Notes:
+%    * Only the last trial reponse is stored in the object itself.
+%    * This feature has not been tested or much used - on our list
+%    * TODO: This could be transformed to be like the rgc computation where
+%      each cell has its own spatial RF. Not there yet, just using
+%      convolutions.
+%    * TODO: We should set this up as a structure that we use to implement
+%      the anatomical rules. Let's send in a struct that defines the
+%      anatomical rules (e.g., anatomyRules) with slots that implement the
+%      kind of stuff listed here.
+%    * Anatomical rules:
+%      - off Diffuse, on Diffuse, and on Midget - Receive no S cone input
+%      - offMidget - keep S cones but scale connection strength down 75%
+%      - onSBC - S cone inputs to center, only L/M cone inputs to surround
 %
-%    [~, bpNTrialsCenter, bpNTrialsSurround] = ...
-%           bp.compute(cMosaic,'nTrialsInput',cMosaicCurrentNTrials);
+% See Also:
+%    Bipolar.m. Wiki <https://github.com/isetbio/isetbio/wiki/bipolar>
 %
-%  The cMosaicCurrentNTrials has dimensions (nTrials,row,col,nFrames), as
-%  returned by cmosaic.computeCurrent.  The full bipolar response simply
-%  add bpNTrialsCenter + bpNTrialsSurround.
-%
-%  Only the last trial reponse is stored in the object itself.
-%
-% Programming todo
-%
-% This could be transformed to be like the rgc computation where each
-% cell has its own spatial RF.  Not there yet, just using convolutions.
-%
-% TODO:  We should set this up as a structure that we use to implement
-% the anatomical rules.  Let's send in a struct that defines the
-% anatomical rules (e.g., anatomyRules) with slots that implement the
-% kind of stuff listed here.
-%
-% Anatomical rules:
-%
-%  off Diffuse, on Diffuse and on Midget - These receive no S cone input
-%  offMidget - keep S cones but scale the connection strength down by 75%
-%  onSBC     - S cone inputs to center, only L/M cone inputs to surround
-%
-% Citations:  See bipolar.m.  Wiki page <>
 
-%
+%% History:
 % 5/2016 JRG (c) isetbio team
+%
+%    10/19/17  jnm  Comments & Formatting
+
+%% Examples
+%{
+   [~, bpNTrialsCenter, bpNTrialsSurround] = ...
+           bp.compute(cMosaic, 'nTrialsInput', cMosaicCurrentNTrials);
+%}
 
 %% parse input parameters
-
 p = inputParser;
 p.addRequired('obj', @(x) (isa(x, 'bipolarMosaic')));
 addParameter(p, 'coneTrials',  [], @isnumeric);
-
+%%%
 % parse - no options at this opint
 p.parse(obj, varargin{:});
 
@@ -85,21 +90,20 @@ coneTrials = p.Results.coneTrials;
 cmosaic    = obj.input;
 
 if isempty(cmosaic.current)
-    error('No cone photocurrent.  Use cmosaic.computeCurrent.');
+    error('No cone photocurrent. Use cmosaic.computeCurrent.');
 end
 
-if ~isempty(coneTrials),  nTrials = size(coneTrials,1);
+if ~isempty(coneTrials),  nTrials = size(coneTrials, 1);
 else,                     nTrials = 1;
 end
 
 %% Spatial filtering and subsampling
-
 % If the input includes multiple trials, we run across all the trials here.
 for iTrial = 1:nTrials
-    
+    %%%
     % This places the cone 3D matrix into a coneNumber x time matrix
     if ~isempty(coneTrials)
-        osSig = RGB2XWFormat(squeeze(coneTrials(iTrial,:,:,:)));
+        osSig = RGB2XWFormat(squeeze(coneTrials(iTrial, :, :, :)));
     else
         osSig = RGB2XWFormat(cmosaic.current);
     end
@@ -107,152 +111,156 @@ for iTrial = 1:nTrials
     
     %% Enforce anatomical rules on cone to bipolar connections
     switch obj.cellType
-        case{'offdiffuse','ondiffuse','onmidget'}
-            
+        case{'offdiffuse', 'ondiffuse', 'onmidget'}
             osSigCenter   = osSig;
             osSigSurround = osSig;
-            
+            %%%
             % Remove S cone input for these types of bipolars
-            
+            %
             % Find the locations indices of the different cone types
-            [~,~,S] = coneTypeLocations(cmosaic,'format','index');
-            
-            % Zero the photocurrent of the S cones. Do this for both the center
-            % and the surround.
-            
+            [~, ~, S] = coneTypeLocations(cmosaic, 'format', 'index');
+            %%%
+            % Zero the photocurrent of the S cones. Do this for both the
+            % center and the surround.
             minval = min(osSig(:));
-            osSigCenter(S(:),:)   = minval*ones(size(osSigCenter(S,:)));
-            osSigSurround(S(:),:) = minval*ones(size(osSigCenter(S,:)));
+            osSigCenter(S(:), :)   = minval*ones(size(osSigCenter(S, :)));
+            osSigSurround(S(:), :) = minval*ones(size(osSigCenter(S, :)));
             
         case{'offmidget'}
+            %%%
             % Keep S cone input for off Midget but only weight by 0.25
-            
+            %
             % Find the locations (row, col) of the different cone types
-            [~,~,S] = coneTypeLocations(cmosaic,'format','index');
-            
+            [~, ~, S] = coneTypeLocations(cmosaic, 'format', 'index');
             minval = min(osSig(:));
             
             osSigCenter   = osSig;
-            osSigCenter(S,:)   = 0.25*(osSigCenter(S,:)-minval)+minval;
+            osSigCenter(S, :)   = 0.25*(osSigCenter(S, :)-minval)+minval;
             
             osSigSurround   = osSig;
-            osSigSurround(S,:) = 0.25*(osSigSurround(S,:)-minval)+minval;
+            osSigSurround(S, :) = 0.25*(osSigSurround(S, :)-minval)+minval;
             
         case{'onsbc'}
+            %%%
             % Set L and M cones to zero in SBC center, set S cones to zero
             % in SBC surround.
-            
+            %
             % Find the indices of the different cone types
-            [L,M,S] = coneTypeLocations(cmosaic,'format','index');
-            
-            % This is one long vector of L,M cone indices
+            [L, M, S] = coneTypeLocations(cmosaic, 'format', 'index');
+            %%%
+            % This is one long vector of L, M cone indices
             LM = [L; M];
-            
+            %%%
             % Find the effectively zero outer segment signal for this
             % mosaic
             minval = min(osSig(:));
-            
+            %%%
             % When the center is an LM cone, make all of the time steps in
             % the center the smallest value
             osSigCenter       = osSig;
-            osSigCenter(LM,:) = minval*ones(size(osSigCenter(LM,:)));
-            
+            osSigCenter(LM, :) = minval*ones(size(osSigCenter(LM, :)));
+            %%%
             % Put effectively zero S-cone signals into the surround
             osSigSurround      = osSig;
-            osSigSurround(S,:) = minval*ones(size(osSigSurround(S,:)));
+            osSigSurround(S, :) = minval*ones(size(osSigSurround(S, :)));
             
         otherwise
-            error('Unrecognized bipolar mosaic type %s\n',obj.cellType);
-            
+            error('Unrecognized bipolar mosaic type %s\n', obj.cellType);
     end
-    
+    %%%
     % Put the data back into RGB format, like RGB2XW()
     sz = size(cmosaic.current);
-    osSigCenter   = XW2RGBFormat(osSigCenter,sz(1),sz(2));
-    osSigSurround = XW2RGBFormat(osSigSurround,sz(1),sz(2));
-    
+    osSigCenter   = XW2RGBFormat(osSigCenter, sz(1), sz(2));
+    osSigSurround = XW2RGBFormat(osSigSurround, sz(1), sz(2));
     % cmosaic.window;
     % vcNewGraphWin; ieMovie(osSigCenter);
     
     %% Spatial filtering
-    
-    % Full spatial convolution for every frame.  The kernel is only 2D
+    % Full spatial convolution for every frame. The kernel is only 2D
     % which is why we have a space-only convolution.
     bipolarCenter   = ieSpaceTimeFilter(osSigCenter, obj.sRFcenter);
     bipolarSurround = ieSpaceTimeFilter(osSigSurround, obj.sRFsurround);
     % vcNewGraphWin; ieMovie(bipolarCenter);
     % vcNewGraphWin; ieMovie(bipolarSurround);
-    
-    % Pull out the samples at the cell locations.  It works here because
-    % they are evenly spaced (stride).  If we have jitter, we need another
+    %%%
+    % Pull out the samples at the cell locations. It works here because
+    % they are evenly spaced (stride). If we have jitter, we need another
     % approach.
-    strideRow = abs(obj.cellLocation(1,2,1) - obj.cellLocation(1,1,1));
-    strideCol = abs(obj.cellLocation(2,1,2) - obj.cellLocation(1,1,2));
+    strideRow = abs(obj.cellLocation(1, 2, 1) - obj.cellLocation(1, 1, 1));
+    strideCol = abs(obj.cellLocation(2, 1, 2) - obj.cellLocation(1, 1, 2));
     
-    bipolarCenter   = bipolarCenter(1:strideRow:end,1:strideCol:end,:);
-    bipolarSurround = bipolarSurround(1:strideRow:end,1:strideCol:end,:);
+    bipolarCenter   = bipolarCenter(1:strideRow:end, 1:strideCol:end, :);
+    bipolarSurround = bipolarSurround(1:strideRow:end, 1:strideCol:end, :);
     
     %% Temporal filtering
-    
     % Reshape the data for the temporal convolution
     [bipolarCenter, row, col] = RGB2XWFormat(bipolarCenter);
     bipolarSurround = RGB2XWFormat(bipolarSurround);
-    
+    %%%
     % This is the impulse response filter
     bipolarFilt = bipolarFilter(obj, cmosaic);
     
     % If we wanted to rectify the signal, we could do it here
-    %
-    % obj.rectify(input,'rType',{hw,fw,none})
-    % obj.responseCenter   = obj.rectificationCenter(bipolarOutputLinearCenter);
-    % obj.responseSurround = obj.rectificationSurround(bipolarOutputLinearSurround);
+    % obj.rectify(input, 'rType', {hw, fw, none})
+    % obj.responseCenter   = ...
+    %    obj.rectificationCenter(bipolarOutputLinearCenter);
+    % obj.responseSurround = ...
+    %    obj.rectificationSurround(bipolarOutputLinearSurround);
     %
     
-    %% Rectification and temporal convolution issues
-    
+    %% Rectification and temporal convolution issues    
     % Rectification - not tested or analyzed
-    
+    %
     % We have in the past shifted the bipolar response levels to a minimum
-    % of zero.  That is arbitrary and produces higher contrast signals.  It
+    % of zero. That is arbitrary and produces higher contrast signals. It
     % might be OK because we have no real units on the bipolar current.
-    % Or, maybe we should leave them alone.  Anyway, here we are shifting
+    % Or, maybe we should leave them alone. Anyway, here we are shifting
     % them to a min of zero.
     
-    % bipolarCenter = obj.rectificationCenter(bipolarCenter - (min(bipolarCenter')'*ones(1,size(bipolarCenter,2))));
-    bipolarCenter = bipolarCenter - (min(bipolarCenter,[],2)*ones(1,size(bipolarCenter,2)));
-    tmpCenter = conv2(bipolarFilt,bipolarCenter);
-    % vcNewGraphWin; tmp = XW2RGBFormat(tmpCenter,row, col); ieMovie(tmp);
-    
+    % bipolarCenter = obj.rectificationCenter(bipolarCenter ...
+    %     - (min(bipolarCenter')'*ones(1, size(bipolarCenter, 2))));
+    bipolarCenter = bipolarCenter - (min(bipolarCenter, [], 2) ...
+        * ones(1, size(bipolarCenter, 2)));
+    tmpCenter = conv2(bipolarFilt, bipolarCenter);
+    % vcNewGraphWin; tmp = XW2RGBFormat(tmpCenter, row, col); ieMovie(tmp);
+    %%%
     % Rectification
     % Not fully tested or analyzed -
-    % bipolarSurround = obj.rectificationSurround(bipolarSurround-(min(bipolarSurround')'*ones(1,size(bipolarSurround,2))));
-    bipolarSurround = bipolarSurround-(min(bipolarSurround,[],2)*ones(1,size(bipolarSurround,2)));
-    tmpSurround = conv2(bipolarFilt,bipolarSurround);
-    % vcNewGraphWin; tmp = XW2RGBFormat(tmpSurround,row, col); ieMovie(tmp);
+    % bipolarSurround = obj.rectificationSurround(bipolarSurround ...
+    %     - (min(bipolarSurround')'*ones(1, size(bipolarSurround, 2))));
+    bipolarSurround = bipolarSurround-(min(bipolarSurround, [], 2) ...
+        * ones(1, size(bipolarSurround, 2)));
+    tmpSurround = conv2(bipolarFilt, bipolarSurround);
+    % vcNewGraphWin;
+    % tmp = XW2RGBFormat(tmpSurround, row, col); ieMovie(tmp);
     
     if ~isempty(coneTrials)
         if iTrial == 1
-            nTrialsCenter = zeros([nTrials,size(XW2RGBFormat(tmpCenter(:,1:cmosaic.tSamples),row,col))]);
-            nTrialsSurround = zeros([nTrials,size(XW2RGBFormat(tmpSurround(:,1:cmosaic.tSamples),row,col))]);
+            nTrialsCenter = zeros([nTrials, size(XW2RGBFormat(...
+                tmpCenter(:, 1:cmosaic.tSamples), row, col))]);
+            nTrialsSurround = zeros([nTrials, size(XW2RGBFormat(...
+                tmpSurround(:, 1:cmosaic.tSamples), row, col))]);
         end
         
-        nTrialsCenter(iTrial,:,:,:) = XW2RGBFormat(tmpCenter(:,1:cmosaic.tSamples),row,col);
-        nTrialsSurround(iTrial,:,:,:) = XW2RGBFormat(tmpSurround(:,1:cmosaic.tSamples),row,col);
+        nTrialsCenter(iTrial, :, :, :) = XW2RGBFormat(...
+            tmpCenter(:, 1:cmosaic.tSamples), row, col);
+        nTrialsSurround(iTrial, :, :, :) = XW2RGBFormat(...
+            tmpSurround(:, 1:cmosaic.tSamples), row, col);
     else
         nTrialsCenter   = 0;
         nTrialsSurround = 0;
     end
     
     if iTrial == nTrials
+        %%%
         % Store the last trial in the object
-        obj.responseCenter   = XW2RGBFormat(tmpCenter(:,1:size(cmosaic.current,3)),row,col);
-        obj.responseSurround = XW2RGBFormat(tmpSurround(:,1:size(cmosaic.current,3)),row,col);
+        obj.responseCenter   = XW2RGBFormat(tmpCenter(:, ...
+            1:size(cmosaic.current, 3)), row, col);
+        obj.responseSurround = XW2RGBFormat(tmpSurround(:, ...
+            1:size(cmosaic.current, 3)), row, col);
     end
-    
-    
 end
 
 response = nTrialsCenter - nTrialsSurround;
-
 
 end

--- a/isettools/bipolar/@bipolarMosaic/describe.m
+++ b/isettools/bipolar/@bipolarMosaic/describe.m
@@ -1,13 +1,21 @@
 function str = describe(obj)
-% DESCRIBE - Summarize the bipolar mosaic properties in a string
+% Syntax:
 %
 %   bipolar.describe;
 %
-% ISSUES:
-%   @JRG:  How will we handle multiple bipolar mosaics?
-%   
-% BW ISETBIO Team, 2017
+% Dexcription:
+%    Summarize the bipolar mosaic properties in a string
+%
+% Notes:
+% * @JRG:  How will we handle multiple bipolar mosaics?
+%
 
+% History:
+% BW ISETBIO Team, 2017
+%
+%    10/18/17  jnm  Comments & formatting
+
+%% Summarize properties
 str = sprintf('Cell type:     \t%s\n',obj.cellType);
 txt = sprintf('Patch size:    \t%.1f um\n',obj.patchSize*1e6);
 str = addText(str,txt);

--- a/isettools/bipolar/@bipolarMosaic/get.m
+++ b/isettools/bipolar/@bipolarMosaic/get.m
@@ -1,49 +1,59 @@
 function val = get(obj, varargin)
-%  Gets isetbio bipolar object parameters
-% 
+% Syntax:
+%
 %    val = bipolar.get(parameter)
 % 
-% Parameters
-%     cellLocation;               % location of bipolar RF center
-%     patchSize;                  % size of retinal patch from sensor
-%     timeStep;                   % time step of simulation from sensor
-%     sRFcenter;                  % spatial RF of the center on the receptor grid
-%     sRFsurround;                % spatial RF of the surround on the receptor grid
-%     temporalDifferentiator;     % differentiator function
-%     responseCenter;             % Store the linear response of the center after convolution
-%     responseSurround;           % Store the linear response of the surround after convolution
-%     response;
-%     threshold;
-%     rgbdata;
-%
+% Description:
+%    Gets isetbio bipolar object parameters
+% 
+% Inputs:
+%    cellLocation           - location of bipolar RF center
+%    patchSize              - size of retinal patch from sensor
+%    timeStep               - time step of simulation from sensor
+%    sRFcenter              - spatial RF of the center on the receptor grid
+%    sRFsurround            - spatial RF of surround on the receptor grid
+%    temporalDifferentiator - differentiator function
+%    responseCenter         - Store the linear response of the center after
+%                             convolution
+%    responseSurround       - Store the linear response of the surround
+%                             after convolution
+%    response               - ???
+%    threshold              - ???
+%    rgbdata                - ???
+
+%% History:
 % 5/2016 JRG (c) isetbio team
-%%
+%
+%    10/18/17  jnm  Comments & formatting
+
+%% Initialize and begin
 p = inputParser;
 p.CaseSensitive = false; 
 p.FunctionName = mfilename;
 p.KeepUnmatched = true;
-
+%%%
 % Make key properties that can be set required arguments, and require
 % values along with key names.
 allowableFields = {...
-    'cellLocation',...
-    'patchSize',...
-    'timeStep',...
-    'sRFcenter',...
-    'sRFsurround',...
-    'spatialrf',...
-    'temporalDifferentiator',...
-    'threshold',...
-    'rgbdata',...
-    'responseCenter','bipolarresponsecenter',...
-    'responseSurround','bipolarresponsesurround',...
-    'response','bipolarresponse'...
+    'cellLocation', ...
     'duration' ...
+    'patchSize', ...
+    'response', 'bipolarresponse'...
+    'responseCenter', 'bipolarresponsecenter', ...
+    'responseSurround', 'bipolarresponsesurround', ...
+    'rgbdata', ...
+    'spatialrf', ...
+    'sRFcenter', ...
+    'sRFsurround', ...
+    'temporalDifferentiator', ...
+    'threshold', ...
+    'timeStep', ...
     };
 
-p.addRequired('what',@(x) any(validatestring(ieParamFormat(x),allowableFields)));
+p.addRequired('what', @(x) any(validatestring(ieParamFormat(x), ...
+    allowableFields)));
 
-% Parse and put results into structure p.
+%% Parse and put results into structure p.
 p.parse(varargin{:}); params = p.Results;
 
 switch ieParamFormat(params.what)  % Lower case and remove spaces
@@ -59,7 +69,7 @@ switch ieParamFormat(params.what)  % Lower case and remove spaces
         
     case {'duration'}
         % In seconds
-        val = obj.timeStep*size(obj.responseCenter,3);
+        val = obj.timeStep*size(obj.responseCenter, 3);
         
     case{'rgbdata'}
         val = obj.rgbData;
@@ -79,13 +89,12 @@ switch ieParamFormat(params.what)  % Lower case and remove spaces
     case{'threshold'}
         val = obj.threshold;
         
-    case{'responsecenter','bipolarresponsecenter'}
+    case{'responsecenter', 'bipolarresponsecenter'}
         val = obj.responseCenter;
         
-    case{'responsesurround','bipolarresponsesurround'}
+    case{'responsesurround', 'bipolarresponsesurround'}
         val = obj.responseSurround;
         
-    case{'response','bipolarresponse'}
+    case{'response', 'bipolarresponse'}
         val = obj.responseCenter - obj.responseSurround;
 end
-

--- a/isettools/bipolar/@bipolarMosaic/initSpace.m
+++ b/isettools/bipolar/@bipolarMosaic/initSpace.m
@@ -1,24 +1,58 @@
-function initSpace(obj,varargin)
-% SPATIALRFINIT - Build spatial receptive fields for the bipolar mosaic
+function initSpace(obj, varargin)
+% Syntax:
 %
-%    @bipolarMosaic.initSpace(varargin)
+%   @bipolarMosaic.initSpace(varargin)
 %
-% Inputs (parameter-values)
-%   eccentricity
-%   spread
-%   spreadRatio
-%   stride
-%   ampCenter
-%   ampSurround
+% Description:
+%    Each bipolar mosaic takes its input from the cone mosaic, so that cell
+%    locations are with respect to the spatial samples of the cone mosaic.
+%    To compute the  spatial spread, we need to account for the cone
+%    spacing. Thus, if the cones are spaced, say 2 um, and the bipolar RF
+%    spans 5 samples, the spatial extent will be 2*5 um. 
 %
-% Each bipolar mosaic takes its input from the cone mosaic, so that cell
-% locations are with respect to the spatial samples of the cone mosaic. To
-% compute the  spatial spread, we need to account for the cone spacing.
-% Thus, if the cones are spaced, say 2 um, and the bipolar RF spans 5
-% samples, the spatial extent will be 2*5 um. 
+% Input:
+%    eccentricity - ???
+%    spread       - ???
+%    spreadRatio  - ???
+%    stride       - ???
+%    ampCenter    - ???
+%    ampSurround  - ???
 %
-% Scientific notes and references
+% Notes:
+%    * Parasol is synonymous with diffuse.
+%    * TODO
+%       - To compute the spread in microns from this specification, 
+%         multiply the number of input samples by the spatial sample
+%         separation of the cones in the mosaic (stored in the input slot).
+%       - We will incorporate a function that changes the size of the
+%         spread and support as a function of eccentricity. For now we just
+%         put in some placeholder numbers. (Let's do better on this
+%         explanation, BW).
+%       - When the layer is deeper, however, we have to keep referring back
+%         through multiple layers. This issue will be addressed in the
+%         RGCLAYER, and then onward.
+%       - We need to write simple utilities that convert from the spatial
+%         units on the cone mosaic into spatial units on the retinal
+%         surface (in um or mm). That will be first implemented in
+%         bipolar.plot('mosaic'). But basically, to do this the units are
+%         X*coneMosaic.patternSampleSize (we think). This doesn't deal with
+%         the jittered cone mosaic yet, but kind of like this. (BW/JRG). 
+% 
 %
+% References:
+% * See 'Extended References' outside of help/doc purview
+% * Field and Chichilnisky, 2010, Nature
+% <http://www.nature.com/nature/journal/v467/n7316/full/nature09424.html>
+% * Dacey, Brainard, Lee, et al., Vision Research, 2000.
+% <http://www.cns.nyu.edu/~tony/vns/readings/dacey-etal-2000.pdf>
+% 
+
+%% History:
+% JRG/BW ISETBIO Team, 2015
+%
+%    10/19/17  jnm  Comments & Formatting
+
+%% Extended References:
 %  Size of the RF
 %  Sampling density (stride) of the RF centers.
 %
@@ -26,14 +60,14 @@ function initSpace(obj,varargin)
 %
 % We have implemented five types of bipolar receptive fields, one assigned
 % to each of the big five RGC types. Each bipolar type has a preferential
-% cone selection rule.  The critical rule is **no S-cones for on/off
+% cone selection rule. The critical rule is **no S-cones for on/off
 % parasol and on-midget**, as per the Chichilnisky primate data (Field and
 % Chichilnisky, 2010, Nature).
 % <http://www.nature.com/nature/journal/v467/n7316/full/nature09424.html>
 %
-% N.B.  Parasol is synonymous with diffuse.
+% N.B. Parasol is synonymous with diffuse.
 %
-% The data for the support size is this passage from Dacey, Brainard, Lee,
+% The data for the support size is this passage from Dacey, Brainard, Lee, 
 % et al., Vision Research, 2000, page 1808 bottom right.
 % (http://www.cns.nyu.edu/~tony/vns/readings/dacey-etal-2000.pdf)
 %
@@ -59,40 +93,17 @@ function initSpace(obj,varargin)
 % junctions) and probably more important among cone bipolars (via gap
 % junctions with AII amacrine cells). - Fred
 %
-% JRG/BW ISETBIO Team, 2015
-%
-%  PROGRAMMING TODO
-%
-% To compute the spread in microns from this specification, multiply the
-% number of input samples by the spatial sample separation of the cones in
-% the mosaic (stored in the input slot).
-%
-% We will incorporate a function that changes the size of the spread and
-% support as a function of eccentricity.  For now we just put in some
-% placeholder numbers. (Let's do better on this explanation, BW).
-%
-% When the layer is deeper, however, we have to keep referring back through
-% multiple layers.  This issue will be addressed in the RGCLAYER, and then
-% onward.
-%
-% We need to write simple utilities that convert from the spatial units on
-% the cone mosaic into spatial units on the retinal surface (in um or mm).
-% That will be first implemented in bipolar.plot('mosaic').  But basically,
-% to do this the units are X*coneMosaic.patternSampleSize (we think).  This
-% doesn't deal with the jittered cone mosaic yet, but kind of like this.
-% (BW/JRG). 
-% 
 
 %% Parse inputs
 p = inputParser;
 p.KeepUnmatched = true;
-p.addParameter('eccentricity',0,@isscalar);
-p.addParameter('spread',[],@isscalar);
-p.addParameter('spreadRatio',10,@isscalar);  % Dacey bipolar paper
+p.addParameter('eccentricity', 0, @isscalar);
+p.addParameter('spread', [], @isscalar);
+p.addParameter('spreadRatio', 10, @isscalar);  % Dacey bipolar paper
 
-p.addParameter('stride',[],@(x)(isempty(x) || isscalar(x)));
-p.addParameter('ampCenter',1,@(x)(isempty(x) || isscalar(x)));
-p.addParameter('ampSurround',1.3,@(x)(isempty(x) || isscalar(x)));
+p.addParameter('stride', [], @(x)(isempty(x) || isscalar(x)));
+p.addParameter('ampCenter', 1, @(x)(isempty(x) || isscalar(x)));
+p.addParameter('ampSurround', 1.3, @(x)(isempty(x) || isscalar(x)));
 
 p.parse(varargin{:});
 
@@ -104,104 +115,112 @@ ampSurround  = p.Results.ampSurround;
 spreadRatio  = p.Results.spreadRatio;  % Surround spread / center spread
 
 %% Select parameters for each cell type
-
 % The spatial samples below (e.g. support and spread) are in units of
-% samples on the cone mosaic.  We can convert this to spatial units on the
+% samples on the cone mosaic. We can convert this to spatial units on the
 % cone mosaic (microns) by multiplying by the cone spatial sampling
-% distance.  The cone mosaic is stored in the input slot of the bipolar
+% distance. The cone mosaic is stored in the input slot of the bipolar
 % mosaic.
 switch obj.cellType
     
-    case{'ondiffuse','offdiffuse'}
+    case{'ondiffuse', 'offdiffuse'}
+        %%%
         % Diffuse bipolars that carry parasol signals
-        
         if isempty(spread)
-            % A functional rule, you could use this.  1 at the central
-            % fovea and 3 cones at 40 deg.  Linear.
+            %%%
+            % A functional rule, you could use this. 1 at the central
+            % fovea and 3 cones at 40 deg. Linear.
             spread =  floor(1 + (2/40)*(eccentricity));
         end
         support = round(4*spread);    % Minimum spatial support
-        
+        %%%
         % Standard deviation of the Gaussian for the center, specified in
-        % spatial samples on the input mosaic.  Anywhere near the center
-        % the input is basically 1 cone.  Far in the periphery, it will be
+        % spatial samples on the input mosaic. Anywhere near the center
+        % the input is basically 1 cone. Far in the periphery, it will be
         % seomthing else that we will have a function for, like the
         % support.
-
+        %
         % We need an amplitude for these functions to be specified in the
         % object.
-        obj.sRFcenter   = ampCenter*fspecial('gaussian',[support, support], spread);
-        
+        obj.sRFcenter   = ampCenter*fspecial('gaussian', [support, ...
+            support], spread);
+        %%%
         % Calculate the spread of the surround
         spreadSurround = spread*spreadRatio;
-        obj.sRFsurround = ampSurround*fspecial('gaussian',[support, support], spreadSurround);
+        obj.sRFsurround = ampSurround*fspecial('gaussian', [support, ...
+            support], spreadSurround);
             
     case {'onsbc'}
-        
+        %%%
         % Small bistratified cells - handle S-cone signals
         % Find reference from Fred/EJ.
         if isempty(spread)
-            % A functional rule, you could use this.  2 at the central
-            % fovea and 5 cones at 40 deg.  Linear.
+            %%%
+            % A functional rule, you could use this. 2 at the central
+            % fovea and 5 cones at 40 deg. Linear.
             spread =  floor(2 + (3/40)*(eccentricity));
         end
         support = round(4*spread);    % Minimum spatial support
-        
+        %%%
         % Reference for very broad surround is in header
-        obj.sRFcenter   = ampCenter*fspecial('gaussian',[support,support],spread);    % convolutional for now
+        obj.sRFcenter   = ampCenter*fspecial('gaussian', [support, ...
+            support], spread);    % convolutional for now
         
         spreadSurround = spread*spreadRatio;
-        obj.sRFsurround = ampSurround*fspecial('gaussian',[support,support],spreadSurround); % convolutional for now
-        
-        
-    case{'onmidget','offmidget'}
-        % Midget bipolars to midget RGCs.  Midgets restrict their centers
+        obj.sRFsurround = ampSurround*fspecial('gaussian', [support, ...
+            support], spreadSurround); % convolutional for now
+
+    case{'onmidget', 'offmidget'}
+        %%%
+        % Midget bipolars to midget RGCs. Midgets restrict their centers
         % to 1 cone out to at least 10 mm in macaque, which is like 40 or
         % 50 deg.
         %
         % See the Psychtoolbox external routine RetinalMMToDegrees for help
         % with mm to degrees in different species.
-        
+
         if isempty(spread)
-            % A functional rule, you could use this.  1 at the central
-            % fovea and 3 cones at 40 deg.  Linear.
+            %%%
+            % A functional rule, you could use this. 1 at the central
+            % fovea and 3 cones at 40 deg. Linear.
             spread =  floor(1 + (2/40)*(eccentricity));
         end
         support = round(4*spread);    % Minimum spatial support
-        
+
         % ecc = 0 mm yields 1x1 cone input to bp
         % ecc = 30 mm yields 3x3 cone input to bp
-        % Support formula extrapolated from data in Dacey ... Lee, 1999 @JRG to insert
-        % support = max(minSupport,floor(1 + (2/10)*(eccentricity)));
-        
-        % Standard deviation of the Gaussian for the center.  Anywhere near
-        % the center the input is basically 1 cone.  Far in the periphery,
+        % Support formula extrapolated from data in Dacey ... Lee, 1999 
+        % @JRG to insert
+        % support = max(minSupport, floor(1 + (2/10)*(eccentricity)));
+        %%%
+        % Standard deviation of the Gaussian for the center. Anywhere near
+        % the center the input is basically 1 cone. Far in the periphery, 
         % it will be seomthing else that we will have a function for, like
         % the support.s
-        obj.sRFcenter   = ampCenter*fspecial('gaussian',[support,support], spread); % convolutional for now
-        
+        obj.sRFcenter   = ampCenter*fspecial('gaussian', [support, ...
+            support], spread); % convolutional for now
+        %%%
         % Calculate the spread of the surround
         spreadSurround = spread*spreadRatio;
-        obj.sRFsurround = ampSurround*fspecial('gaussian',[support,support], spreadSurround); % convolutional for now
-        
-end
+        obj.sRFsurround = ampSurround*fspecial('gaussian', [support, ...
+            support], spreadSurround); % convolutional for now
 
+end
+%%%
 % The bipolar RF center positions are stored with respect to the samples of
 % the input layer (cone mosaic). The weights are also stored with respect
 % to the input sample.
 if isempty(stride), stride = round(spread); end
-
-% Cone row and column positions, but centered around (0,0).
+%%%
+% Cone row and column positions, but centered around (0, 0).
 % These should be spaced by an amount that is controlled by a parameter and
 % reflects the size of the receptive field.
 conemosaic = obj.input;
-[X,Y] = meshgrid(1:stride:conemosaic.cols,1:stride:conemosaic.rows);
+[X, Y] = meshgrid(1:stride:conemosaic.cols, 1:stride:conemosaic.rows);
 X = X - mean(X(:)); Y = Y - mean(Y(:));
-
-% Put them in the (row,col,X/Y) tensor.
-obj.cellLocation = zeros(size(X,1),size(X,2),2);
-obj.cellLocation(:,:,1) = X;
-obj.cellLocation(:,:,2) = Y;
+%%%
+% Put them in the (row, col, X/Y) tensor.
+obj.cellLocation = zeros(size(X, 1), size(X, 2), 2);
+obj.cellLocation(:, :, 1) = X;
+obj.cellLocation(:, :, 2) = Y;
 
 end
-

--- a/isettools/bipolar/@bipolarMosaic/plot.m
+++ b/isettools/bipolar/@bipolarMosaic/plot.m
@@ -1,111 +1,135 @@
 function hdl = plot(obj, pType, varargin)
-% Plot data from a bipolar mosaic object
-% 
-%    hdl = bp.plot(plotType, varargin)
+% Syntax:
 %
-% Type @bipolarMosaic.plot('help'); to see the plot types.
+%   hdl = bp.plot(plotType, varargin)
 %
-% Optional parameters-value pairs
-%   gamma - controls image display
-%   pos   - positions to plot for time series
+%   Type @bipolarMosaic.plot('help'); to see the plot types.
 %
-% Examples:
-%   bpMosaics = bpL.mosaic;
+% Description:
+%    Plot data from a bipolar mosaic object
 %
-%   bpMosaics{1}.plot('spatial rf')
-%   bpMosaics{1}.plot('mosaic');
-%   bpMosaics{1}.plot('response center');
-%   bpMosaics{1}.plot('response time series','pos',[5 5]);
-%   bpMosaics{1}.plot('response image','gamma',0.3);
-%   bpMosaics{1}.plot('response movie');
+% Input:
+%    obj      - ???
+%    pType    - plot type
+%    varargin - ???
 %
-% 5/2016 JRG,BW (c) isetbio team
+% Optional Key/Value Pairs:
+%    gamma    - controls image display
+%    pos      - positions to plot for time series
+%
 
+%% History: 
+% 5/2016 JRG, BW (c) isetbio team
+%
+%    10/18/17  jnm  Comments & Formatting
+
+%% Examples:
+%{
+   bpMosaics = bpL.mosaic;
+   bpMosaics{1}.plot('spatial rf')
+   bpMosaics{1}.plot('mosaic');
+   bpMosaics{1}.plot('response center');
+   bpMosaics{1}.plot('response time series', 'pos', [5 5]);
+   bpMosaics{1}.plot('response image', 'gamma', 0.3);
+   bpMosaics{1}.plot('response movie');
+%}
 %% Parse inputs
-
 p = inputParser; 
 p.CaseSensitive = false; 
 p.FunctionName  = mfilename;
 p.KeepUnmatched = true;
-
+%%%
 % Make key properties that can be set required arguments, and require
 % values along with key names.
 allowPlots = {...
-    'help',...
-    'responsetimeseries','responsecenter','responsesurround',...
-    'responseimage','responsemovie', ...
-    'spatialrf','surroundrf','mosaic'};
-p.addRequired('pType',@(x) any(validatestring(ieParamFormat(x),allowPlots)));
+    'help', ...
+    'responsetimeseries', 'responsecenter', 'responsesurround', ...
+    'responseimage', 'responsemovie', ...
+    'spatialrf', 'surroundrf', 'mosaic'};
+p.addRequired('pType', @(x) any(validatestring(ieParamFormat(x), ...
+    allowPlots)));
 
-p.addParameter('gamma',1,@isscalar);
-p.addParameter('pos',[],@ismatrix);
-
+p.addParameter('gamma', 1, @isscalar);
+p.addParameter('pos', [], @ismatrix);
+%%%
 % Parse pType
 % Additional parameters are pulled out in the case statements, below.
-p.parse(pType,varargin{:}); 
+p.parse(pType, varargin{:}); 
 
-%% Set the window.  Maybe this should be obj.fig???
-if ~strcmpi(pType,'help'), hdl = gcf; end  %vcNewGraphWin([],'upperLeftBig');
+%% Set the window.
+% < Note: JM - opinion on the question that was already listed here? ->
+% Maybe this should be obj.fig??? >
+if ~strcmpi(pType, 'help'), hdl = gcf; end
+%vcNewGraphWin([], 'upperLeftBig');
 sz = size(obj.responseCenter);
-
+%%%
 % Programming:
 % We need to get the units of time from the object, not as per below.
-
 % Options
 switch ieParamFormat(pType)
     case 'help'
-        fprintf('\nKnown %s plot types\n--------------\n',class(obj));
+        %% Case: Help
+        fprintf('\nKnown %s plot types\n--------------\n', class(obj));
         for ii=2:length(allowPlots)
-            fprintf('\t%s\n',allowPlots{ii});
+            fprintf('\t%s\n', allowPlots{ii});
         end
         hdl = [];
         return;
     case 'spatialrf'
-        % @bipolarMosaic.plot('spatial rf')
+        %% Case: Spatial RF
+        %   @bipolarMosaic.plot('spatial rf')
         srf = obj.sRFcenter - obj.sRFsurround;
         sz = size(srf); 
-        if isequal(sz,[1, 1])
+        if isequal(sz, [1, 1])
             disp('spatial rf is an impulse');
             return;
         end
         
         x = (1:sz(2)) - mean(1:sz(2));    
         y = (1:sz(1)) - mean(1:sz(1)); 
-        surf(x,y,srf); colormap(parula);
+        surf(x, y, srf); colormap(parula);
         xlabel('Cone samples'); zlabel('Responsivity')
         
     case 'surroundrf'
-        % @bipolarMosaic.plot('surround rf')
+        %% Case: Surround RF
+        %   @bipolarMosaic.plot('surround rf')
         srf = obj.sRFsurround;
         sz = size(srf);
-        if isequal(sz,[1, 1])
+        if isequal(sz, [1, 1])
             disp('spatial rf is an impulse');
             return;
         end
         
         x = (1:sz(2)) - mean(1:sz(2));
         y = (1:sz(1)) - mean(1:sz(1));
-        surf(x,y,srf); colormap(parula);
-        xlabel('Cone samples'); zlabel('Responsivity')
+        surf(x, y, srf);
+        colormap(parula);
+        xlabel('Cone samples');
+        zlabel('Responsivity')
         
     case {'mosaic'}
-        % @bipolarMosaic.plot('mosaic') - Shows RF array
-        % Get contour lines for mosaic RFs
+        %% Case: Mosaic
+        %   @bipolarMosaic.plot('mosaic')
+        % 
+        % Shows the RF Array, gets contour lines for mosaic RFs
         % The cell locations are specified with respect to the cone mosaic
         % input layer.  We would like to present them in terms of microns
         % on the cone mosaic surface.  So, we transform the cell locations
         % to microns.
-                
+
+        %%%  
         % These are sampled w.r.t. the input mosaic.  We convert to microns
         center = obj.cellLocation;  
-        % List the (x,y) positions on the grid and count how many
-        center = reshape(center,[size(obj.cellLocation,1)*size(obj.cellLocation,2),2]);
-        nCells = size(center,1);
-        [r,c,~] = size(obj.cellLocation);
-        
+        %%%
+        % List the (x, y) positions on the grid and count how many
+        center = reshape(center, [size(obj.cellLocation, 1) ...
+            * size(obj.cellLocation, 2), 2]);
+        nCells = size(center, 1);
+        [r, c, ~] = size(obj.cellLocation);
+        %%%
         % Convert sample grid positions to distance in microns
-        metersPerBipolar = obj.patchSize ./ [r,c];
-        
+        metersPerBipolar = obj.patchSize ./ [r, c];
+        %%%
         % Determine the RF radius.
         % Calculate the radius.  This seems too special case.  Ask JRG what
         % he intended here.  It seems like he thinks the radius is
@@ -113,82 +137,96 @@ switch ieParamFormat(pType)
         % At this moment, we are calculating the radius of the support in
         % microns. We probably want to have parameters that define the
         % support and the spread separately.
-        center = 1e6*center*diag(metersPerBipolar(:));  % Centers in microns
+        center = 1e6 * center * diag(metersPerBipolar(:));
+        % Centers in microns
         metersPerInput   = obj.input.patternSampleSize(1);
-        radius = (1e6*metersPerInput*size(obj.sRFcenter,1))/2;  
-                
+        radius = (1e6 * metersPerInput * size(obj.sRFcenter, 1)) / 2;  
+        %%%
         % At this point we should have centers and radius in terms of
         % microns.  If life is goo
-        xMin = min(center(:,2)) - 3*radius; xMax = max(center(:,2)) + 3*radius;
-        yMin = min(center(:,2)) - 3*radius; yMax = max(center(:,2)) + 3*radius;
+        xMin = min(center(:, 2)) - 3 * radius;
+        xMax = max(center(:, 2)) + 3 * radius;
+        yMin = min(center(:, 2)) - 3 * radius;
+        yMax = max(center(:, 2)) + 3 * radius;
         titleS = sprintf('RF positions and sizes');
-        
+        %%%
         % If there are a lot ... sub sample
         maxSamples = 500;
-        if size(center,1) > maxSamples
-            center = center(randi(nCells,[maxSamples,1]),:);
-            titleS = sprintf('Sampled RF positions and sizes (%d of %d)',maxSamples,size(obj.cellLocation(:),1));
+        if size(center, 1) > maxSamples
+            center = center(randi(nCells, [maxSamples, 1]), :);
+            titleS = sprintf(['Sampled RF positions and sizes '...
+                '(%d of %d)'], maxSamples, size(obj.cellLocation(:), 1));
         end
-        
+        %%%
         % The whole ellipse thing isn't handled really, is it?  I mean, the
         % parameter is fixed here, and not set.
         ellipseMatrix = [1 1 0];        
-        ieShape('ellipse',...
-            'center',center,...
-            'radius',radius,...
-            'ellipseParameters',ellipseMatrix,...
-            'color','b');
-        
+        ieShape('ellipse', ...
+            'center', center, ...
+            'radius', radius, ...
+            'ellipseParameters', ellipseMatrix, ...
+            'color', 'b');
+        %%%
         % Sets the axis limits
-        set(gca,'xlim',[xMin,xMax],'ylim',[yMin,yMax]);
-        xlabel(sprintf('Distance (\\mum)'),'fontsize',14);
-        ylabel(sprintf('Distance (\\mum)'),'fontsize',14);
+        set(gca, 'xlim', [xMin, xMax], 'ylim', [yMin, yMax]);
+        xlabel(sprintf('Distance (\\mum)'), 'fontsize', 14);
+        ylabel(sprintf('Distance (\\mum)'), 'fontsize', 14);
         title(titleS);
             
     case{'responsecenter'}
-        % @bipolarMosaic.plot('response center')
-        % @bipolarMosaic.plot('response center','pos',[1,1]);
-        % TODO - add cell lcation
+        %% Case: Response Center
+        %   @bipolarMosaic.plot('response center')
+        %   @bipolarMosaic.plot('response center', 'pos', [1, 1]);
+        %
+        %
+        % TODO - add cell location
         pos = p.Results.pos;
         if isempty(pos)
+            %%%
             % Put position in the rows, time in the columns
             responseRS = RGB2XWFormat(obj.responseCenter);
         else
-            nPos = size(pos,1);
-            responseRS = zeros(nPos,size(obj.responseCenter,3));
+            nPos = size(pos, 1);
+            responseRS = zeros(nPos, size(obj.responseCenter, 3));
             for ii=1:nPos
-                responseRS(ii,:) = obj.responseCenter(pos(ii,1),pos(ii,2),:);
+                responseRS(ii, :) = obj.responseCenter(pos(ii, 1), ...
+                    pos(ii, 2), :);
             end
         end
-        
+        %%%
         % Show it
         vcNewGraphWin;
-        plot(obj.timeStep*(1:sz(3)),responseRS');
+        plot(obj.timeStep * (1:sz(3)), responseRS');
         xlabel('Time (sec)'); ylabel('Response (AU)');
         title('Center response(s)'); grid on
         
     case{'responsesurround'}
-        % @bipolarMosaic.plot('response surround')
-        % responseRS = reshape(obj.responseSurround,sz(1)*sz(2),sz(3));
+        %% Case: Response Surround
+        %   @bipolarMosaic.plot('response surround')
+        %   responseRS = reshape(obj.responseSurround, sz(1)*sz(2), sz(3));
         pos = p.Results.pos;
         if isempty(pos)
+            %%%
             % Put position in the rows, time in the columns
             responseRS = RGB2XWFormat(obj.responseSurround);
         else
-            nPos = size(pos,1);
-            responseRS = zeros(nPos,size(obj.responseSurround,3));
+            nPos = size(pos, 1);
+            responseRS = zeros(nPos, size(obj.responseSurround, 3));
             for ii=1:nPos
-                responseRS(ii,:) = obj.responseSurround(pos(ii,1),pos(ii,2),:);
+                responseRS(ii, :) = obj.responseSurround(pos(ii, 1), ...
+                    pos(ii, 2), :);
             end
         end
         
         vcNewGraphWin;
-        plot(obj.timeStep*(1:sz(3)),responseRS);
-        xlabel('Time (sec)'); ylabel('Response (AU)');
+        plot(obj.timeStep * (1:sz(3)), responseRS);
+        xlabel('Time (sec)');
+        ylabel('Response (AU)');
         title('Bipolar surround response'); grid on
         
     case{'responsetimeseries'}
-        % @bipolarMosaic.plot('response time series','pos',...)
+        %% Case: Response Time Series
+        %   @bipolarMosaic.plot('response time series', 'pos', ...)
         %
         % Open a new window and show the time series, but not in any
         % particular organized way. Only up to 200 samples are shown.
@@ -196,75 +234,85 @@ switch ieParamFormat(pType)
         %
         pos = p.Results.pos;
         if isempty(pos)
-            responseRS = RGB2XWFormat(obj.responseCenter - obj.responseSurround);  
-            nCells = size(responseRS,1);
+            responseRS = RGB2XWFormat(obj.responseCenter ...
+                - obj.responseSurround);  
+            nCells = size(responseRS, 1);
         else
-            nPos = size(pos,1);
-            responseRS = zeros(nPos,size(obj.responseSurround,3));
+            nPos = size(pos, 1);
+            responseRS = zeros(nPos, size(obj.responseSurround, 3));
             for ii=1:nPos
-                responseRS(ii,:) = obj.responseCenter(pos(ii,1),pos(ii,2),:) - obj.responseSurround(pos(ii,1),pos(ii,2),:);
+                responseRS(ii, :) = obj.responseCenter(pos(ii, 1), ...
+                    pos(ii, 2), :) - obj.responseSurround(pos(ii, 1), ...
+                    pos(ii, 2), :);
             end            
         end
-        tSamples = obj.timeStep*(1:size(obj.responseCenter,3));
+        tSamples = obj.timeStep * (1:size(obj.responseCenter, 3));
         
         vcNewGraphWin;
         if isempty(pos) &&  nCells > 100
+            %%%
             % 100 randomly sampled positions
-            cSamples = randi(nCells,[100,1]);
-            plot(tSamples,responseRS(cSamples,:));
+            cSamples = randi(nCells, [100, 1]);
+            plot(tSamples, responseRS(cSamples, :));
             title('Bipolar current (100 samples)');
         elseif isempty(pos)
+            %%%
             % All of the spatial samples
-            plot(tSamples,responseRS);
+            plot(tSamples, responseRS);
             title('Bipolar current');
         else
             % From a single point
-            plot(tSamples,responseRS)
+            plot(tSamples, responseRS)
             title(sprintf('Selected positions'));
         end
         
-        xlabel(sprintf('Time (sec, \\Deltat %.0f ms)',obj.timeStep*1e3));
+        xlabel(sprintf('Time (sec, \\Deltat %.0f ms)', ...
+            obj.timeStep * 1e3));
         ylabel('Current (a.u.)');
         grid on
         
     case{'responseimage'}
+        %% Case: Response Image
         %
-        % @bipolarMosaic.plot('response image')
+        %   @bipolarMosaic.plot('response image')
         %
         response = (obj.get('response'));
-        patchSizeUM = obj.patchSize*1e6;
-        dx = patchSizeUM/size(response,1);  % Step in microns
-        rowSamples = dx(1)*(1:size(response,1)); 
+        patchSizeUM = obj.patchSize * 1e6;
+        dx = patchSizeUM / size(response, 1);  % Step in microns
+        rowSamples = dx(1) * (1:size(response, 1)); 
         rowSamples = rowSamples - mean(rowSamples);
-        colSamples = dx(2)*(1:size(response,2));
+        colSamples = dx(2) * (1:size(response, 2));
         colSamples = colSamples - mean(colSamples);
-        
+        %%%
         % The gamma has to deal with negative numbers, sigh.
         if p.Results.gamma ~= 1
-            img = mean(response,3);
+            img = mean(response, 3);
             img(img>=0) = img(img>=0).^p.Results.gamma;
-            img(img<0)  = ((-1)*img(img<0)*p.Results.gamma)*-1;
+            img(img<0)  = ((-1) * img(img<0) * p.Results.gamma) * -1;
         else
-            img = mean(response,3);
+            img = mean(response, 3);
         end
         
-        imagesc(rowSamples,colSamples,img);
+        imagesc(rowSamples, colSamples, img);
         axis image; colormap(gray(256)); title('Current (a.u.)');
         xlabel(sprintf('Cell position (\\mum)'));
         
     case{'responsemovie'}
+        %% Case: Response Movie
         % Pass the varargin along
         if ~isempty(varargin) && length(varargin) == 1
+            %%%
             % Params are coded in a single struct
             varargin{1}.hf = hdl;
             if p.Results.gamma ~= 1
                 varargin{1}.gamma = p.Results.gamma;
             end
-            ieMovie(obj.get('response'),varargin{:});
+            ieMovie(obj.get('response'), varargin{:});
         else
+            %%%
             % Params are coded in param/value
             varargin{end+1} = 'gamma'; varargin{end+1} = p.Results.gamma;
-            ieMovie(obj.get('response'),'hf',hdl,varargin{:});
+            ieMovie(obj.get('response'), 'hf', hdl, varargin{:});
         end
 end
 

--- a/isettools/bipolar/@bipolarMosaic/set.m
+++ b/isettools/bipolar/@bipolarMosaic/set.m
@@ -1,75 +1,91 @@
 function obj = set(obj, varargin)
-%  Gets isetbio bipolar object parameters.
+% Syntax: 
+%
+%   < insert syntax example here!>
+%
+% Description:
+%    Gets isetbio bipolar object parameters.
 % 
-% The bipolar object allows the simulated cone responses to be passed on to
-% the inner retina object and to approxiately maintain its impulse
-% response. This will allow us to run the nonlinear biophysical cone outer
-% segment model and pass its results on to the bipolar stage and then RGCs.
+%    The bipolar object allows the simulated cone responses to be passed on
+%    to the inner retina object and to approxiately maintain its impulse
+%    response. This will allow us to run the nonlinear biophysical cone
+%    outer segment model and pass its results on to the bipolar stage and
+%    then RGCs.
 % 
-%     cellLocation;                    % location of bipolar RF center
-%     patchSize;                       % size of retinal patch from sensor
-%     timeStep;                        % time step of simulation from sensor
-%     sRFcenter;                       % spatial RF of the center on the receptor grid
-%     sRFsurround;                     % spatial RF of the surround on the receptor grid
-%     temporalDifferentiator;          % differentiator function
-%     responseCenter;                  % Store the linear response of the center after convolution
-%     responseSurround;                % Store the linear response of the surround after convolution
-% 
-% 
-% 5/2016 JRG (c) isetbio team
-%%
+% Inputs:
+%    Properties amenable to being set.
+%
+%    cellLocation           - location of bipolar RF center
+%    patchSize              - size of retinal patch from sensor
+%    timeStep               - time step of simulation from sensor
+%    sRFcenter              - spatial RF of the center on the receptor grid
+%    sRFsurround            - spatial RF of the surround on receptor grid
+%    temporalDifferentiator - differentiator function
+%    responseCenter         - Store linear response of the center after
+%                             convolution
+%    responseSurround       - Store linear response of the surround after
+%                             convolution
+%
 
+%% History 
+% 5/2016 JRG (c) isetbio team
+%
+%    10/18/17  jnm  Comments & formatting
+
+%% Initialize and begin
 narginchk(0, Inf);
-p = inputParser; p.CaseSensitive = false; p.FunctionName = mfilename;
+p = inputParser;
+p.CaseSensitive = false;
+p.FunctionName = mfilename;
 p.KeepUnmatched = true;
+%%%
 % Make key properties that can be set required arguments, and require
 % values along with key names.
 allowableFieldsToSet = {...
-    'cellLocation',...
-    'patchSize',...
-    'timeStep',...
-    'sRFcenter',...
-    'sRFsurround',...
-    'tIR',...
-    'temporalDifferentiator',...
-    'threshold',...
-    'responseCenter','bipolarresponsecenter',...    
-    'responseSurround','bipolarresponsesurround'...
+    'cellLocation', ...
+    'patchSize', ...
+    'responseCenter', 'bipolarresponsecenter', ...    
+    'responseSurround', 'bipolarresponsesurround'...
+    'sRFcenter', ...
+    'sRFsurround', ...
+    'temporalDifferentiator', ...
+    'threshold', ...
+    'timeStep', ...
+    'tIR', ...
     };
-p.addRequired('what',@(x) any(validatestring(ieParamFormat(x),allowableFieldsToSet)));
+p.addRequired('what', @(x) any(validatestring(ieParamFormat(x), ...
+    allowableFieldsToSet)));
 p.addRequired('value');
-
-% Parse and put results into structure p.
+%% Parse and put results into structure p.
 p.parse(varargin{:}); params = p.Results;
 
-switch ieParamFormat(params.what);  % Lower case and remove spaces
-
-    case {'celllocation'}        
+switch ieParamFormat(params.what)  % Lower case and remove spaces
+    case {'celllocation'}
         obj.cellLocation = params.value;
-                
+
     case{'patchsize'}
         obj.patchSize = params.value;
-        
+
     case{'timestep'}
         obj.timeStep = params.value;
-        
+
     case{'rgbdata'}
         obj.rgbData = params.value;
-        
+
     case{'srfcenter'}
         obj.sRFcenter = params.value;
-        
+
     case{'srfsurround'}
         obj.sRFsurround = params.value;
-        
+
     case{'threshold'}
         obj.threshold = params.value;
-        
+
     case{'responsecenter'}
         obj.responseCenter = params.value;
-        
+
     case{'responsesurround'}
         obj.responseSurround = params.value;
-        
+
 end
 


### PR DESCRIPTION
General:
 - Fixing spacing: spaces between operators, spaces after commas, etc...
 - Adding section breaks (and non-breaks) for publishing-style documentation in the body of the code.
BipoarMosaic
 - Changed spacing in Key/Value pairs section for consistency
 - Class definition still missing explanations for several properties:
    - Constructor
    - rectificationCenter property
    - rectificationSurround property
    - responseCenter property
    - responseSurround property
    - validCellTypes property
    - cellsPerDistance method
    - describe method
    - get method
    - plot method
    - window method
BipolarSet
 - Changed spacing in Key/Value pairs section for consistency
 - Alphabetized AllowableFieldsToSet
    - Note: Several allowable fields are not listed under Inputs. Is this intentionally done? (bipolarResponseCenter, bipolarResponseSurround, threshold, tIR)
 - Need syntax examples still
Compute
 - Please make sure I didn't butcher the Description and References sections!
 - Separated wall of text into an 'extended references' section to not scroll the syntax section out when using help. (still very long)
 - Expand on the options (M & C) and what they offer/constrain?
 - Several ToDo's that need to be addressed
Describe
 - Note to @JRG needs to be addressed
Get
 - Alphabetized AllowableFieldsToSet
    - Note: Several allowable fields are not listed under Inputs. Is this intentionally done? (duration, bipolarResponse, bipolarResponseCenter, bipolarResponseSurround, rgbData, spatialRF)
 - Several input are still missing descriptions
 - Changed spacing in Inputs section for consistency
InitSpace
 - All input arguments need descriptions
 - Separated wall of text into an 'extended references' section to not scroll the syntax section out when using help. (still very long)
 - ToDo item(s) to be addressed
Plot
 - Better long description
 - There are several notes that need attention
 - A couple of inputs need descriptions
 - 1+ ToDo's in the body still need  to be addressed (ex. add cell loc.)
 - To address the 'sigh' section -- why multipled by -1 twice?
Set
 - Need syntax examples still
 - Alphabetized AllowableFieldsToSet
    - Note: Several allowable fields are not listed under Inputs. Is this intentionally done? (bipolarResponseCenter, bipolarResponseSurround, threshold, tIR)